### PR TITLE
fix: gtag.js new consent settings to prevent cookies

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -52,6 +52,7 @@ export const onRenderBody = ({
     gtag('config', '${trackingId}', {
       send_page_view: false,
       client_storage: 'none',
+      analytics_storage: 'denied',
       client_id: effectiveClientId
     });
   `}}/>);


### PR DESCRIPTION
https://developers.google.com/tag-platform/security/guides/consent#set_consent_defaults

Seems like client_storage is no longer valid
Using analytics_storage instead